### PR TITLE
Add usage hints for Display Name placeholder usage

### DIFF
--- a/includes/html/pages/device/edit/device.inc.php
+++ b/includes/html/pages/device/edit/device.inc.php
@@ -132,7 +132,7 @@ $disable_notify = get_dev_attrib($device, 'disable_notify');
             <button type="button" name="hostname-edit-button" id="hostname-edit-button" class="btn btn-danger" onclick="toggleHostnameEdit()"> <i class="fa fa-pencil"></i> </button>
         </div>
     </div>
-    <div class="form-group" data-toggle="tooltip" data-container="body" data-placement="bottom" title="Display Name for this device.  Keep short. Available placeholders: hostname, sysName, sysName_fallback, ip" >
+    <div class="form-group" data-toggle="tooltip" data-container="body" data-placement="bottom" title="Display Name for this device.  Keep short. Available placeholders: hostname, sysName, sysName_fallback, ip (e.g. '{{ $sysName }}')" >
         <label for="edit-display-input" class="col-sm-2 control-label" >Display Name</label>
         <div class="col-sm-6">
             <input type="text" id="edit-display-input" name="display" class="form-control" placeholder="System Default" value="<?php echo htmlentities($device_model->display); ?>">


### PR DESCRIPTION
Adds some usage for placeholders in the Display Name tooltip

![image](https://user-images.githubusercontent.com/9220123/154770409-25c3da80-7e65-4aba-bebd-650fdc04ac5e.png)

DO NOT DELETE THE UNDERLYING TEXT

#### Please note

> Please read this information carefully. You can run `./lnms dev:check` to check your code before submitting.

- [x] Have you followed our [code guidelines?](https://docs.librenms.org/Developing/Code-Guidelines/)
- [x] If my Pull Request does some changes/fixes/enhancements in the WebUI, I have inserted a screenshot of it.
- [ ] If my Pull Request makes discovery/polling/yaml changes, I have added/updated [test data](https://docs.librenms.org/Developing/os/Test-Units/).

#### Testers

If you would like to test this pull request then please run: `./scripts/github-apply <pr_id>`, i.e `./scripts/github-apply 5926`
After you are done testing, you can remove the changes with `./scripts/github-remove`.  If there are schema changes, you can ask on discord how to revert.
